### PR TITLE
add class for tabs containing invalid field values

### DIFF
--- a/src/Tabs.vue
+++ b/src/Tabs.vue
@@ -3,7 +3,7 @@
     <li
       v-for="tab in tabs"
       role="presentation"
-      :class="[{ 'active': tab.id == selected }, { 'disabled': tab.disabled }]"
+      :class="[{ 'active': tab.id == selected }, { 'disabled': tab.disabled }, { 'invalid': tab.invalidFields }]"
     >
       <a href @click.prevent="select(tab.id)">
         {{ tab.name }}


### PR DESCRIPTION
This PR adds a special `invalid` class to tab buttons depending on `tab.invalidFields` flag. The purpose is to highlight a tab that contains fields that need user attention ( i.e. their values are invalid )